### PR TITLE
Adjective rule for names ending with "om"

### DIFF
--- a/commonItems/Linguistics/adjective_rules.txt
+++ b/commonItems/Linguistics/adjective_rules.txt
@@ -593,6 +593,7 @@
 {"*oa", "*oese"}, // Genoa
 {"*oe", "*oese"}, // Faroe
 {"*oh", "*ohan"},
+{"*om", "*omian"},
 {"*on", "*onese"}, // Gabon
 {"*oy", "*ojan"}, // Troy
 {"*os", "*ian"}, // Thasos

--- a/commonItems/commonItems.csproj
+++ b/commonItems/commonItems.csproj
@@ -6,7 +6,7 @@
 
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
     <PackageId>PGCG.$(AssemblyName)</PackageId>
-    <Version>8.3.3</Version>
+    <Version>8.4.0</Version>
     <Authors>PGCG</Authors>
     <PackageProjectUrl>https://github.com/ParadoxGameConverters/commonItems.NET</PackageProjectUrl>
     <RepositoryUrl>https://github.com/ParadoxGameConverters/commonItems.NET</RepositoryUrl>


### PR DESCRIPTION
closes #347 