### PR TITLE
More graceful handling of undefined named colors

### DIFF
--- a/commonItems/Colors/Color.cs
+++ b/commonItems/Colors/Color.cs
@@ -60,6 +60,13 @@ public class Color : IPDXSerializable {
 	public Color(double h, double s, double v, double alpha) : this(h, s, v) {
 		A = alpha;
 	}
+	
+	public Color(System.Drawing.Color color) {
+		RgbComponents[0] = color.R;
+		RgbComponents[1] = color.G;
+		RgbComponents[2] = color.B;
+		DeriveHsvFromRgb();
+	}
 
 	public override bool Equals(object? obj) {
 		return obj is Color color && RgbComponents.SequenceEqual(color.RgbComponents);

--- a/commonItems/commonItems.csproj
+++ b/commonItems/commonItems.csproj
@@ -6,7 +6,7 @@
 
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
     <PackageId>PGCG.$(AssemblyName)</PackageId>
-    <Version>9.2.0</Version>
+    <Version>10.0.0</Version>
     <Authors>PGCG</Authors>
     <PackageProjectUrl>https://github.com/ParadoxGameConverters/commonItems.NET</PackageProjectUrl>
     <RepositoryUrl>https://github.com/ParadoxGameConverters/commonItems.NET</RepositoryUrl>


### PR DESCRIPTION
related exception reported by Sentry, which can be avoided with this change:
![obraz](https://github.com/ParadoxGameConverters/PGCG.commonItems/assets/29546927/bb887355-8e5c-4b51-a122-2657d8e1dc4f)
