### PR TITLE
CommonRegexes.Date: accept incomplete dates

### DIFF
--- a/commonItems.UnitTests/CommonRegexesTests.cs
+++ b/commonItems.UnitTests/CommonRegexesTests.cs
@@ -227,10 +227,16 @@ public class CommonRegexesTests {
 	}
 
 	[Fact]
-	public void DateRegexRequiresThreeSections() {
-		Assert.DoesNotMatch(CommonRegexes.Date, "1918.11");
-		Assert.DoesNotMatch(CommonRegexes.Date, "1918");
-		Assert.DoesNotMatch(CommonRegexes.Date, "");
+	public void DateRegexMatchesIncompleteDates() {
+		Assert.Matches(CommonRegexes.Date, "1918.11.");
+		Assert.Matches(CommonRegexes.Date, "1918.11");
+		Assert.Matches(CommonRegexes.Date, "1918.");
+		Assert.Matches(CommonRegexes.Date, "1918");
+
+		Assert.Matches(CommonRegexes.Date, "-1918.11.");
+		Assert.Matches(CommonRegexes.Date, "-1918.11");
+		Assert.Matches(CommonRegexes.Date, "-1918.");
+		Assert.Matches(CommonRegexes.Date, "-1918");
 	}
 	
 	[Fact]

--- a/commonItems.UnitTests/DateTests.cs
+++ b/commonItems.UnitTests/DateTests.cs
@@ -50,8 +50,8 @@ public class DateTests {
 	public void DateLogsBadInitializationFromBadString() {
 		var output = new StringWriter();
 		Console.SetOut(output);
-		_ = new Date("2020a.january.32");
-		Assert.Contains("[WARN] Problem constructing date from string 2020a.january.32: Input string was not in a correct format.", output.ToString());
+		_ = new Date("2020.january.32");
+		Assert.Contains("[WARN] Problem constructing date from string \"2020.january.32\": The input string 'january' was not in a correct format.", output.ToString());
 	}
 
 	[Fact]

--- a/commonItems.UnitTests/DateTests.cs
+++ b/commonItems.UnitTests/DateTests.cs
@@ -11,10 +11,11 @@ public class DateTests {
 	private const int DecimalPlaces = 4;
 
 	[Fact]
-	public void DefaultDateIsNotSet() {
+	public void DateDefaultsToFirstJanuaryFirst() {
 		var date = new Date();
-		Assert.False(date.IsSet());
+		Assert.Equal("1.1.1", date.ToString());
 	}
+
 	[Fact]
 	public void DateCanBeCopyConstructed() {
 		var baseDate = new Date(500, 1, 1);
@@ -38,23 +39,19 @@ public class DateTests {
 	}
 
 	[Fact]
-	public void DateLogsBadInitialization() {
+	public void DateLogsBadInitializationFromEmptyString() {
 		var output = new StringWriter();
 		Console.SetOut(output);
-		_ = new Date("2020.4");
-		Assert.Contains("[WARN] Problem inputting date: System.ArgumentOutOfRangeException", output.ToString());
+		_ = new Date("");
+		Assert.Contains("[WARN] Problem constructing date: at least a year should be provided!", output.ToString());
 	}
 
 	[Fact]
-	public void DateIsNotSetOnBadInitialization() {
-		var date = new Date("2020.4");
-		Assert.False(date.IsSet());
-	}
-
-	[Fact]
-	public void DateIsOneJanuaryFirstOnBadInitialization() {
-		var date = new Date("2020.4");
-		Assert.Equal("1.1.1", date.ToString());
+	public void DateLogsBadInitializationFromBadString() {
+		var output = new StringWriter();
+		Console.SetOut(output);
+		_ = new Date("2020a.january.32");
+		Assert.Contains("[WARN] Problem constructing date from string 2020a.january.32: Input string was not in a correct format.", output.ToString());
 	}
 
 	[Fact]
@@ -330,5 +327,17 @@ public class DateTests {
 		Assert.Equal(expectedYear, dateTimeOffset.Year);
 		Assert.Equal(expectedMonth, dateTimeOffset.Month);
 		Assert.Equal(expectedDay, dateTimeOffset.Day);
+	}
+
+	[Theory]
+	[InlineData("1450.10.", 1450, 10, 1)]
+	[InlineData("1450.10", 1450, 10, 1)]
+	[InlineData("1450.", 1450, 1, 1)]
+	[InlineData("1450", 1450, 1, 1)]
+	public void IncompleteDateElementsDefaultTo1(string dateStr, int expectedYear, int expectedMonth, int expectedDay) {
+		Date pdxDate = dateStr;
+		Assert.Equal(expectedYear, pdxDate.Year);
+		Assert.Equal(expectedMonth, pdxDate.Month);
+		Assert.Equal(expectedDay, pdxDate.Day);
 	}
 }

--- a/commonItems/CommonRegexes.cs
+++ b/commonItems/CommonRegexes.cs
@@ -38,7 +38,7 @@ public static partial class CommonRegexes {
 	private static partial Regex GetFloatRegex();
 	[GeneratedRegex("^\"-?\\d+(.\\d+)?\"$")]
 	private static partial Regex GetQuotedFloatRegex();
-	[GeneratedRegex("^\\-?\\d+[.]\\d+[.]\\d+$")]
+	[GeneratedRegex("^-?\\d+([.]\\d+)?([.]\\d+)?\\.?$")]
 	private static partial Regex GetDateRegex();
 	[GeneratedRegex(@"^""[^\n\""]+""$")]
 	private static partial Regex GetQuotedStringRegex();


### PR DESCRIPTION
CK3 has multiple instances of incomplete dates in character history. Some log lines from IRToCK3:

```
2024-05-01 15:03:12 [DEBUG] Ignored history keywords: 640.1.
2024-05-01 15:03:12 [DEBUG] Ignored history keywords: 889
2024-05-01 15:03:12 [DEBUG] Ignored history keywords: 1019.1.
2024-05-01 15:03:12 [DEBUG] Ignored history keywords: 1058.1.
2024-05-01 15:03:12 [DEBUG] Ignored history keywords: 1065.1.
2024-05-01 15:03:13 [DEBUG] Ignored history keywords: 1077.1
2024-05-01 15:03:13 [DEBUG] Ignored history keywords: 1101.1
2024-05-01 15:03:14 [DEBUG] Ignored history keywords: 976.1
2024-05-01 15:03:14 [DEBUG] Ignored history keywords: 880.1.1.
2024-05-01 15:03:14 [DEBUG] Ignored history keywords: 1049
2024-05-01 15:03:15 [DEBUG] Ignored history keywords: 939.1.
2024-05-01 15:03:15 [DEBUG] Ignored history keywords: 841.1.1.
2024-05-01 15:03:15 [DEBUG] Ignored history keywords: 1046
2024-05-01 15:03:15 [DEBUG] Ignored history keywords: 879.1.
```