### PR TITLE
Add the Builtin class to a namespace

### DIFF
--- a/commonItems/ConverterVersion.cs
+++ b/commonItems/ConverterVersion.cs
@@ -86,7 +86,7 @@ public class ConverterVersion {
 		sb.Append(GetDescription());
 		sb.Append('\n');
 		sb.Append("* Built on ");
-		var compileTime = new DateTime(Builtin.CompileTime, DateTimeKind.Utc);
+		var compileTime = new DateTime(Builtins.Builtin.CompileTime, DateTimeKind.Utc);
 		sb.Append(compileTime.ToString("u", CultureInfo.InvariantCulture));
 		sb.Append('\n');
 

--- a/commonItems/commonItems.csproj
+++ b/commonItems/commonItems.csproj
@@ -6,7 +6,7 @@
 
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
     <PackageId>PGCG.$(AssemblyName)</PackageId>
-    <Version>12.3.0</Version>
+    <Version>12.3.1</Version>
     <Authors>PGCG</Authors>
     <PackageProjectUrl>https://github.com/ParadoxGameConverters/commonItems.NET</PackageProjectUrl>
     <RepositoryUrl>https://github.com/ParadoxGameConverters/commonItems.NET</RepositoryUrl>
@@ -118,7 +118,7 @@
   </ItemGroup>
 
   <Target Name="Date" BeforeTargets="CoreCompile">
-    <WriteLinesToFile File="$(IntermediateOutputPath)gen.cs" Lines="static partial class Builtin { public static long CompileTime = $([System.DateTime]::UtcNow.Ticks) %3B }" Overwrite="true" />
+    <WriteLinesToFile File="$(IntermediateOutputPath)gen.cs" Lines="namespace Builtins { static partial class Builtin { public static long CompileTime = $([System.DateTime]::UtcNow.Ticks) %3B } }" Overwrite="true" />
     <ItemGroup>
       <Compile Include="$(IntermediateOutputPath)gen.cs" />
     </ItemGroup>


### PR DESCRIPTION
Fixes a warning in ImperatorToCK3.