### PR TITLE
ModFS: return ModFSFileInfo objects list in GetAllFilesInFolder

### DIFF
--- a/commonItems.UnitTests/Mods/ModFilesystemTests.cs
+++ b/commonItems.UnitTests/Mods/ModFilesystemTests.cs
@@ -163,8 +163,8 @@ public sealed class ModFilesystemTests {
 		var modFS = new ModFilesystem("TestFiles/ModFilesystem/GetActualFileLocation/game_root", new List<Mod>());
 
 		modFS.GetAllFilesInFolder("test_folder").Should().Equal(
-			"TestFiles/ModFilesystem/GetActualFileLocation/game_root/test_folder/root_file.txt",
-			"TestFiles/ModFilesystem/GetActualFileLocation/game_root/test_folder/test_file.txt");
+			new ModFSFileInfo("root_file.txt", "TestFiles/ModFilesystem/GetActualFileLocation/game_root/test_folder/root_file.txt"),
+			new ModFSFileInfo("test_file.txt", "TestFiles/ModFilesystem/GetActualFileLocation/game_root/test_folder/test_file.txt"));
 	}
 
 	[Fact]
@@ -173,9 +173,9 @@ public sealed class ModFilesystemTests {
 		var modFS = new ModFilesystem("TestFiles/ModFilesystem/GetActualFileLocation/game_root", new[] {modOne});
 
 		modFS.GetAllFilesInFolder("test_folder").Should().Equal(
-			"TestFiles/ModFilesystem/GetActualFileLocation/mod_one/test_folder/mod_one_file.txt",
-			"TestFiles/ModFilesystem/GetActualFileLocation/game_root/test_folder/root_file.txt",
-			"TestFiles/ModFilesystem/GetActualFileLocation/mod_one/test_folder/test_file.txt");
+			new ModFSFileInfo("mod_one_file.txt", "TestFiles/ModFilesystem/GetActualFileLocation/mod_one/test_folder/mod_one_file.txt"),
+			new ModFSFileInfo("root_file.txt", "TestFiles/ModFilesystem/GetActualFileLocation/game_root/test_folder/root_file.txt"),
+			new ModFSFileInfo("test_file.txt", "TestFiles/ModFilesystem/GetActualFileLocation/mod_one/test_folder/test_file.txt"));
 	}
 
 	[Fact]
@@ -186,10 +186,10 @@ public sealed class ModFilesystemTests {
 			new[] {modOne, modTwo});
 
 		modFS.GetAllFilesInFolder("test_folder").Should().Equal(
-			"TestFiles/ModFilesystem/GetActualFileLocation/mod_one/test_folder/mod_one_file.txt",
-			"TestFiles/ModFilesystem/GetActualFileLocation/mod_two/test_folder/mod_two_file.txt",
-			"TestFiles/ModFilesystem/GetActualFileLocation/game_root/test_folder/root_file.txt",
-			"TestFiles/ModFilesystem/GetActualFileLocation/mod_two/test_folder/test_file.txt");
+			new ModFSFileInfo("mod_one_file.txt", "TestFiles/ModFilesystem/GetActualFileLocation/mod_one/test_folder/mod_one_file.txt"),
+				new ModFSFileInfo("mod_two_file.txt", "TestFiles/ModFilesystem/GetActualFileLocation/mod_two/test_folder/mod_two_file.txt"),
+				new ModFSFileInfo("root_file.txt", "TestFiles/ModFilesystem/GetActualFileLocation/game_root/test_folder/root_file.txt"),
+				new ModFSFileInfo("test_file.txt", "TestFiles/ModFilesystem/GetActualFileLocation/mod_two/test_folder/test_file.txt"));
 	}
 
 	[Fact]
@@ -201,8 +201,8 @@ public sealed class ModFilesystemTests {
 			new[] {modOne, modTwo});
 
 		modFS.GetAllFilesInFolder("test_folder").Should().Equal(
-			"TestFiles/ModFilesystem/GetActualFileLocation/mod_two/test_folder/mod_two_file.txt",
-			"TestFiles/ModFilesystem/GetActualFileLocation/mod_two/test_folder/test_file.txt");
+			new ModFSFileInfo("mod_two_file.txt", "TestFiles/ModFilesystem/GetActualFileLocation/mod_two/test_folder/mod_two_file.txt"),
+			new ModFSFileInfo("test_file.txt", "TestFiles/ModFilesystem/GetActualFileLocation/mod_two/test_folder/test_file.txt"));
 	}
 
 	private sealed class CustomPrecedenceComparer : IComparer<string> {
@@ -226,8 +226,8 @@ public sealed class ModFilesystemTests {
 			new[] {modOne, modTwo});
 
 		modFS.GetAllFilesInFolder("test_folder", new CustomPrecedenceComparer()).Should().Equal(
-			"TestFiles/ModFilesystem/GetActualFileLocation/mod_two/test_folder/mod_two_file.txt",
-			"TestFiles/ModFilesystem/GetActualFileLocation/mod_two/test_folder/test_file.txt");
+			new ModFSFileInfo("mod_two_file.txt", "TestFiles/ModFilesystem/GetActualFileLocation/mod_two/test_folder/mod_two_file.txt"),
+			new ModFSFileInfo("test_file.txt", "TestFiles/ModFilesystem/GetActualFileLocation/mod_two/test_folder/test_file.txt"));
 	}
 
 	[Fact]
@@ -310,24 +310,24 @@ public sealed class ModFilesystemTests {
 		var modFS = new ModFilesystem("TestFiles/ModFilesystem/GetActualFileLocation/game_root", new List<Mod>());
 
 		modFS.GetAllFilesInFolderRecursive("test_folder").Should().Equal(
-			"TestFiles/ModFilesystem/GetActualFileLocation/game_root/test_folder/root_file.txt",
-			"TestFiles/ModFilesystem/GetActualFileLocation/game_root/test_folder/test_file.txt",
-			"TestFiles/ModFilesystem/GetActualFileLocation/game_root/test_folder/deeper_folder/dummy.txt",
-			"TestFiles/ModFilesystem/GetActualFileLocation/game_root/test_folder/game_folder/dummy.txt");
+			new ModFSFileInfo("root_file.txt", "TestFiles/ModFilesystem/GetActualFileLocation/game_root/test_folder/root_file.txt"),
+			new ModFSFileInfo("test_file.txt", "TestFiles/ModFilesystem/GetActualFileLocation/game_root/test_folder/test_file.txt"),
+			new ModFSFileInfo("deeper_folder/dummy.txt", "TestFiles/ModFilesystem/GetActualFileLocation/game_root/test_folder/deeper_folder/dummy.txt"),
+			new ModFSFileInfo("game_folder/dummy.txt", "TestFiles/ModFilesystem/GetActualFileLocation/game_root/test_folder/game_folder/dummy.txt"));
 	}
 
 	[Fact]
 	public void ModFilesAndSubfoldersAddToAndReplaceGameRootFiles() {
 		var modOne = new Mod("Mod One", "TestFiles/ModFilesystem/GetActualFileLocation/mod_one");
 		var modFS = new ModFilesystem("TestFiles/ModFilesystem/GetActualFileLocation/game_root", new[] {modOne});
-
+		
 		modFS.GetAllFilesInFolderRecursive("test_folder").Should().Equal(
-			"TestFiles/ModFilesystem/GetActualFileLocation/mod_one/test_folder/mod_one_file.txt",
-			"TestFiles/ModFilesystem/GetActualFileLocation/game_root/test_folder/root_file.txt",
-			"TestFiles/ModFilesystem/GetActualFileLocation/mod_one/test_folder/test_file.txt",
-			"TestFiles/ModFilesystem/GetActualFileLocation/mod_one/test_folder/deeper_folder/dummy.txt",
-			"TestFiles/ModFilesystem/GetActualFileLocation/game_root/test_folder/game_folder/dummy.txt",
-			"TestFiles/ModFilesystem/GetActualFileLocation/mod_one/test_folder/mod_one_folder/dummy.txt");
+			new ModFSFileInfo("mod_one_file.txt", "TestFiles/ModFilesystem/GetActualFileLocation/mod_one/test_folder/mod_one_file.txt"),
+			new ModFSFileInfo("root_file.txt", "TestFiles/ModFilesystem/GetActualFileLocation/game_root/test_folder/root_file.txt"),
+			new ModFSFileInfo("test_file.txt", "TestFiles/ModFilesystem/GetActualFileLocation/mod_one/test_folder/test_file.txt"),
+			new ModFSFileInfo("deeper_folder/dummy.txt", "TestFiles/ModFilesystem/GetActualFileLocation/mod_one/test_folder/deeper_folder/dummy.txt"),
+			new ModFSFileInfo("game_folder/dummy.txt", "TestFiles/ModFilesystem/GetActualFileLocation/game_root/test_folder/game_folder/dummy.txt"),
+			new ModFSFileInfo("mod_one_folder/dummy.txt", "TestFiles/ModFilesystem/GetActualFileLocation/mod_one/test_folder/mod_one_folder/dummy.txt"));
 	}
 
 	[Fact]
@@ -338,14 +338,14 @@ public sealed class ModFilesystemTests {
 			new[] {modOne, modTwo});
 
 		modFS.GetAllFilesInFolderRecursive("test_folder").Should().Equal(
-			"TestFiles/ModFilesystem/GetActualFileLocation/mod_one/test_folder/mod_one_file.txt",
-			"TestFiles/ModFilesystem/GetActualFileLocation/mod_two/test_folder/mod_two_file.txt",
-			"TestFiles/ModFilesystem/GetActualFileLocation/game_root/test_folder/root_file.txt",
-			"TestFiles/ModFilesystem/GetActualFileLocation/mod_two/test_folder/test_file.txt",
-			"TestFiles/ModFilesystem/GetActualFileLocation/mod_two/test_folder/deeper_folder/dummy.txt",
-			"TestFiles/ModFilesystem/GetActualFileLocation/game_root/test_folder/game_folder/dummy.txt",
-			"TestFiles/ModFilesystem/GetActualFileLocation/mod_one/test_folder/mod_one_folder/dummy.txt",
-			"TestFiles/ModFilesystem/GetActualFileLocation/mod_two/test_folder/mod_two_folder/dummy.txt");
+			new ModFSFileInfo("mod_one_file.txt", "TestFiles/ModFilesystem/GetActualFileLocation/mod_one/test_folder/mod_one_file.txt"),
+			new ModFSFileInfo("mod_two_file.txt", "TestFiles/ModFilesystem/GetActualFileLocation/mod_two/test_folder/mod_two_file.txt"),
+			new ModFSFileInfo("root_file.txt", "TestFiles/ModFilesystem/GetActualFileLocation/game_root/test_folder/root_file.txt"),
+			new ModFSFileInfo("test_file.txt", "TestFiles/ModFilesystem/GetActualFileLocation/mod_two/test_folder/test_file.txt"),
+			new ModFSFileInfo("deeper_folder/dummy.txt", "TestFiles/ModFilesystem/GetActualFileLocation/mod_two/test_folder/deeper_folder/dummy.txt"),
+			new ModFSFileInfo("game_folder/dummy.txt", "TestFiles/ModFilesystem/GetActualFileLocation/game_root/test_folder/game_folder/dummy.txt"),
+			new ModFSFileInfo("mod_one_folder/dummy.txt", "TestFiles/ModFilesystem/GetActualFileLocation/mod_one/test_folder/mod_one_folder/dummy.txt"),
+			new ModFSFileInfo("mod_two_folder/dummy.txt", "TestFiles/ModFilesystem/GetActualFileLocation/mod_two/test_folder/mod_two_folder/dummy.txt"));
 	}
 
 	[Fact]
@@ -357,10 +357,10 @@ public sealed class ModFilesystemTests {
 			new[] {modOne, modTwo});
 
 		modFS.GetAllFilesInFolderRecursive("test_folder").Should().Equal(
-			"TestFiles/ModFilesystem/GetActualFileLocation/mod_two/test_folder/mod_two_file.txt",
-			"TestFiles/ModFilesystem/GetActualFileLocation/mod_two/test_folder/test_file.txt",
-			"TestFiles/ModFilesystem/GetActualFileLocation/mod_two/test_folder/deeper_folder/dummy.txt",
-			"TestFiles/ModFilesystem/GetActualFileLocation/mod_two/test_folder/mod_two_folder/dummy.txt");
+			new ModFSFileInfo("mod_two_file.txt", "TestFiles/ModFilesystem/GetActualFileLocation/mod_two/test_folder/mod_two_file.txt"),
+			new ModFSFileInfo("test_file.txt", "TestFiles/ModFilesystem/GetActualFileLocation/mod_two/test_folder/test_file.txt"),
+			new ModFSFileInfo("deeper_folder/dummy.txt", "TestFiles/ModFilesystem/GetActualFileLocation/mod_two/test_folder/deeper_folder/dummy.txt"),
+			new ModFSFileInfo("mod_two_folder/dummy.txt", "TestFiles/ModFilesystem/GetActualFileLocation/mod_two/test_folder/mod_two_folder/dummy.txt"));
 	}
 
 	[Fact]
@@ -372,10 +372,10 @@ public sealed class ModFilesystemTests {
 			new[] {modOne, modTwo});
 
 		modFS.GetAllFilesInFolderRecursive("test_folder", new CustomPrecedenceComparer()).Should().Equal(
-			"TestFiles/ModFilesystem/GetActualFileLocation/mod_two/test_folder/mod_two_folder/dummy.txt",
-			"TestFiles/ModFilesystem/GetActualFileLocation/mod_two/test_folder/deeper_folder/dummy.txt",
-			"TestFiles/ModFilesystem/GetActualFileLocation/mod_two/test_folder/mod_two_file.txt",
-			"TestFiles/ModFilesystem/GetActualFileLocation/mod_two/test_folder/test_file.txt");
+			new ModFSFileInfo("mod_two_folder/dummy.txt", "TestFiles/ModFilesystem/GetActualFileLocation/mod_two/test_folder/mod_two_folder/dummy.txt"),
+			new ModFSFileInfo("deeper_folder/dummy.txt", "TestFiles/ModFilesystem/GetActualFileLocation/mod_two/test_folder/deeper_folder/dummy.txt"),
+			new ModFSFileInfo("mod_two_file.txt", "TestFiles/ModFilesystem/GetActualFileLocation/mod_two/test_folder/mod_two_file.txt"),
+			new ModFSFileInfo("test_file.txt", "TestFiles/ModFilesystem/GetActualFileLocation/mod_two/test_folder/test_file.txt"));
 	}
 
 	[Fact]
@@ -385,13 +385,13 @@ public sealed class ModFilesystemTests {
 		var modFS = new ModFilesystem("TestFiles/ModFilesystem/GetActualFileLocation/game_root", new []{modOne, modTwo});
 
 		modFS.GetAllFilesInFolderRecursive("test_folder/").Should().Equal(
-			"TestFiles/ModFilesystem/GetActualFileLocation/mod_one/test_folder/mod_one_file.txt",
-			"TestFiles/ModFilesystem/GetActualFileLocation/mod_two/test_folder/mod_two_file.txt",
-			"TestFiles/ModFilesystem/GetActualFileLocation/game_root/test_folder/root_file.txt",
-			"TestFiles/ModFilesystem/GetActualFileLocation/mod_two/test_folder/test_file.txt",
-			"TestFiles/ModFilesystem/GetActualFileLocation/mod_two/test_folder/deeper_folder/dummy.txt",
-			"TestFiles/ModFilesystem/GetActualFileLocation/game_root/test_folder/game_folder/dummy.txt",
-			"TestFiles/ModFilesystem/GetActualFileLocation/mod_one/test_folder/mod_one_folder/dummy.txt",
-			"TestFiles/ModFilesystem/GetActualFileLocation/mod_two/test_folder/mod_two_folder/dummy.txt");
+			new ModFSFileInfo("mod_one_file.txt", "TestFiles/ModFilesystem/GetActualFileLocation/mod_one/test_folder/mod_one_file.txt"),
+			new ModFSFileInfo("mod_two_file.txt", "TestFiles/ModFilesystem/GetActualFileLocation/mod_two/test_folder/mod_two_file.txt"),
+			new ModFSFileInfo("root_file.txt", "TestFiles/ModFilesystem/GetActualFileLocation/game_root/test_folder/root_file.txt"),
+			new ModFSFileInfo("test_file.txt", "TestFiles/ModFilesystem/GetActualFileLocation/mod_two/test_folder/test_file.txt"),
+			new ModFSFileInfo("deeper_folder/dummy.txt", "TestFiles/ModFilesystem/GetActualFileLocation/mod_two/test_folder/deeper_folder/dummy.txt"),
+			new ModFSFileInfo("game_folder/dummy.txt", "TestFiles/ModFilesystem/GetActualFileLocation/game_root/test_folder/game_folder/dummy.txt"),
+			new ModFSFileInfo("mod_one_folder/dummy.txt", "TestFiles/ModFilesystem/GetActualFileLocation/mod_one/test_folder/mod_one_folder/dummy.txt"),
+			new ModFSFileInfo("mod_two_folder/dummy.txt", "TestFiles/ModFilesystem/GetActualFileLocation/mod_two/test_folder/mod_two_folder/dummy.txt"));
 	}
 }

--- a/commonItems/Localization/LocDB.cs
+++ b/commonItems/Localization/LocDB.cs
@@ -20,8 +20,8 @@ public class LocDB : IdObjectCollection<string, LocBlock> {
 		Logger.Info("Reading Localization...");
 
 		var locFiles = modFS.GetAllFilesInFolderRecursive("localization")
-			.Where(f => CommonFunctions.GetExtension(f) == "yml");
-		var locLinesCount = locFiles.Sum(ScrapeFile);
+			.Where(f => CommonFunctions.GetExtension(f.RelativePath) == "yml");
+		var locLinesCount = locFiles.Select(f => f.AbsolutePath).Sum(ScrapeFile);
 		
 		Logger.Info($"{locLinesCount} localization lines read.");
 	}

--- a/commonItems/Mods/ModFSFileInfo.cs
+++ b/commonItems/Mods/ModFSFileInfo.cs
@@ -1,0 +1,6 @@
+﻿namespace commonItems.Mods;
+
+public struct ModFSFileInfo(string relativePath, string absolutePath) {
+	public string RelativePath = relativePath;
+	public string AbsolutePath = absolutePath;
+}

--- a/commonItems/Mods/ModFilesystem.cs
+++ b/commonItems/Mods/ModFilesystem.cs
@@ -101,7 +101,7 @@ public sealed class ModFilesystem {
 		return Directory.Exists(pathInGameRoot) ? pathInGameRoot : null;
 	}
 
-	public OrderedSet<string> GetAllFilesInFolder(string path, IComparer<string> filePrecedenceComparer) {
+	public List<ModFSFileInfo> GetAllFilesInFolder(string path, IComparer<string> filePrecedenceComparer) {
 		var foundFiles = new SortedDictionary<string, string>(filePrecedenceComparer); // <relative path, full path>
 
 		foreach (var mod in mods.Reverse()) {
@@ -116,7 +116,10 @@ public sealed class ModFilesystem {
 			}
 
 			if (PathIsReplaced(path, mod.ReplacedFolders)) {
-				return foundFiles.Values.ToOrderedSet();
+				return foundFiles.Select(f => new ModFSFileInfo {
+					RelativePath = f.Key.Replace('\\', '/'),
+					AbsolutePath= f.Value,
+				}).ToList();
 			}
 		}
 
@@ -130,9 +133,12 @@ public sealed class ModFilesystem {
 			foundFiles.Add(newFile, fullPath);
 		}
 
-		return foundFiles.Values.ToOrderedSet();
+		return foundFiles.Select(f => new ModFSFileInfo {
+			RelativePath = f.Key.Replace('\\', '/'),
+			AbsolutePath= f.Value,
+		}).ToList();
 	}
-	public OrderedSet<string> GetAllFilesInFolder(string path) {
+	public List<ModFSFileInfo> GetAllFilesInFolder(string path) {
 		return GetAllFilesInFolder(path, precedenceComparer);
 	}
 	
@@ -172,7 +178,7 @@ public sealed class ModFilesystem {
 		return GetAllSubfolders(path, precedenceComparer);
 	}
 
-	public OrderedSet<string> GetAllFilesInFolderRecursive(string path, IComparer<string> filePrecedenceComparer) {
+	public List<ModFSFileInfo> GetAllFilesInFolderRecursive(string path, IComparer<string> filePrecedenceComparer) {
 		var foundFiles = new SortedDictionary<string, string>(filePrecedenceComparer); // <relative path, full path>
 
 		foreach (var mod in mods.Reverse()) {
@@ -187,7 +193,10 @@ public sealed class ModFilesystem {
 			}
 
 			if (PathIsReplaced(path, mod.ReplacedFolders)) {
-				return foundFiles.Values.ToOrderedSet();
+				return foundFiles.Select(f => new ModFSFileInfo {
+					RelativePath = f.Key.Replace('\\', '/'),
+					AbsolutePath= f.Value,
+				}).ToList();
 			}
 		}
 
@@ -201,10 +210,13 @@ public sealed class ModFilesystem {
 			foundFiles.Add(newFile, fullPath);
 		}
 
-		return foundFiles.Values.ToOrderedSet();
+		return foundFiles.Select(f => new ModFSFileInfo {
+			RelativePath = f.Key.Replace('\\', '/'),
+			AbsolutePath= f.Value,
+		}).ToList();
 	}
 
-	public OrderedSet<string> GetAllFilesInFolderRecursive(string path) {
+	public List<ModFSFileInfo> GetAllFilesInFolderRecursive(string path) {
 		return GetAllFilesInFolderRecursive(path, precedenceComparer);
 	}
 	#endregion

--- a/commonItems/Parser.cs
+++ b/commonItems/Parser.cs
@@ -401,15 +401,15 @@ public class Parser {
 	public void ParseGameFolder(string relativePath, ModFilesystem modFS, string extensions, bool recursive, bool logFilePaths = false, bool parallel = false) {
 		var extensionSet = extensions.Split(';');
 
-		OrderedSet<string> files;
+		List<ModFSFileInfo> files;
 		if (recursive) {
 			files = modFS.GetAllFilesInFolderRecursive(relativePath);
 		} else {
 			files = modFS.GetAllFilesInFolder(relativePath);
 		}
-		files.RemoveWhere(f => !extensionSet.Contains(CommonFunctions.GetExtension(f)));
+		files.RemoveWhere(f => !extensionSet.Contains(CommonFunctions.GetExtension(f.RelativePath)));
 
-		files.ForEach(ProcessFile, allowParallel: parallel);
+		files.Select(f => f.AbsolutePath).ForEach(ProcessFile, allowParallel: parallel);
 
 		return;
 

--- a/commonItems/commonItems.csproj
+++ b/commonItems/commonItems.csproj
@@ -6,7 +6,7 @@
 
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
     <PackageId>PGCG.$(AssemblyName)</PackageId>
-    <Version>13.0.1</Version>
+    <Version>14.0.0</Version>
     <Authors>PGCG</Authors>
     <PackageProjectUrl>https://github.com/ParadoxGameConverters/commonItems.NET</PackageProjectUrl>
     <RepositoryUrl>https://github.com/ParadoxGameConverters/commonItems.NET</RepositoryUrl>


### PR DESCRIPTION
This allows us to see the relative path of a ModFS file, not just its absolute path.