### PR TITLE
Defines: ignore semicolons

### DIFF
--- a/commonItems.UnitTests/DefinesTests.cs
+++ b/commonItems.UnitTests/DefinesTests.cs
@@ -1,0 +1,20 @@
+﻿using commonItems.Mods;
+using System;
+using Xunit;
+
+namespace commonItems.UnitTests;
+
+public class DefinesTests {
+	private const string GameRoot = "TestFiles/CK3/game";
+	private readonly ModFilesystem modFS = new(GameRoot, Array.Empty<Mod>());
+	
+	[Fact]
+	public void DefinesAreCorrectlyLoaded() {
+		var defines = new Defines();
+		defines.LoadDefines(modFS);
+		
+		Assert.Equal("-30", defines.GetValue("NDomicile", "TEMPERAMENT_THRESHOLD_LOW"));
+		Assert.Equal("\"event:/SFX/UI/Actions/sfx_ui_action_sacrifice\"", defines.GetValue("NTest", "RELIGION_SACRIFICE"));
+		Assert.Equal("\"snapshot:/States/MainMenu\"", defines.GetValue("NTest", "FRONTEND_HANDLER_SNAPSHOT"));
+	}
+}

--- a/commonItems.UnitTests/TestFiles/CK3/game/common/defines/00_defines.txt
+++ b/commonItems.UnitTests/TestFiles/CK3/game/common/defines/00_defines.txt
@@ -1,3 +1,8 @@
 ﻿NDomicile = {
 	TEMPERAMENT_THRESHOLD_LOW = -30		# Follower opinion of domicile owner is less than or equal to x, resulting in a negative domicile effect
 }
+
+NTest = {
+	RELIGION_SACRIFICE = "event:/SFX/UI/Actions/sfx_ui_action_sacrifice"; # The ';' character should be ignored.
+	FRONTEND_HANDLER_SNAPSHOT = "snapshot:/States/MainMenu"
+}

--- a/commonItems.UnitTests/commonItems.UnitTests.csproj
+++ b/commonItems.UnitTests/commonItems.UnitTests.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Meziantou.Analyzer" Version="2.0.172">
+    <PackageReference Include="Meziantou.Analyzer" Version="2.0.173">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/commonItems/Defines.cs
+++ b/commonItems/Defines.cs
@@ -1,4 +1,5 @@
 ﻿using commonItems.Mods;
+using System;
 using System.Collections.Generic;
 
 namespace commonItems;
@@ -16,6 +17,7 @@ public class Defines {
 			}
 			
 			var definesParser = new Parser();
+			definesParser.RegisterKeyword(";", reader => { }); // Ignore the semicolons.
 			definesParser.RegisterRegex(CommonRegexes.String, (reader, key) => {
 				var stfOfItem = reader.GetStringOfItem();
 				category[key] = stfOfItem.ToString();

--- a/commonItems/Defines.cs
+++ b/commonItems/Defines.cs
@@ -1,5 +1,4 @@
 ﻿using commonItems.Mods;
-using System;
 using System.Collections.Generic;
 
 namespace commonItems;

--- a/commonItems/commonItems.csproj
+++ b/commonItems/commonItems.csproj
@@ -6,7 +6,7 @@
 
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
     <PackageId>PGCG.$(AssemblyName)</PackageId>
-    <Version>15.0.0</Version>
+    <Version>15.0.1</Version>
     <Authors>PGCG</Authors>
     <PackageProjectUrl>https://github.com/ParadoxGameConverters/commonItems.NET</PackageProjectUrl>
     <RepositoryUrl>https://github.com/ParadoxGameConverters/commonItems.NET</RepositoryUrl>


### PR DESCRIPTION
Found in Imperator:

> 	RELIGION_SACRIFICE = "event:/SFX/UI/Actions/sfx_ui_action_sacrifice";
	FRONTEND_HANDLER_SNAPSHOT = "snapshot:/States/MainMenu"