### PR TITLE
Log CPU name

### DIFF
--- a/commonItems.sln.DotSettings
+++ b/commonItems.sln.DotSettings
@@ -4,6 +4,7 @@
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=AUC/@EntryIndexedValue">AUC</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=BOM/@EntryIndexedValue">BOM</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=CM/@EntryIndexedValue">CM</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=CPU/@EntryIndexedValue">CPU</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=DB/@EntryIndexedValue">DB</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=FS/@EntryIndexedValue">FS</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=GOG/@EntryIndexedValue">GOG</s:String>

--- a/commonItems/DebugInfo.cs
+++ b/commonItems/DebugInfo.cs
@@ -19,7 +19,7 @@ public static class DebugInfo {
 		HardwareInfo hardwareInfo;
 		try {
 			hardwareInfo = new();
-			hardwareInfo.RefreshCPUList();
+			hardwareInfo.RefreshCPUList(includePercentProcessorTime: false);
 		} catch (Exception e) {
 			Logger.Debug($"Exception was raised when detecting CPUs: {e.Message}");
 			return;

--- a/commonItems/DebugInfo.cs
+++ b/commonItems/DebugInfo.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using Hardware.Info;
+using System;
 using System.Globalization;
 using System.Linq;
 using System.Management;
@@ -12,6 +13,21 @@ public static class DebugInfo {
 		Logger.DebugFormat("Operating system: {0}", os.VersionString);
 		CultureInfo ci = CultureInfo.InstalledUICulture;
 		Logger.DebugFormat("Installed UI language: {0}", ci.Name);
+	}
+	
+	public static void LogCPUInfo() {
+		HardwareInfo hardwareInfo;
+		try {
+			hardwareInfo = new();
+			hardwareInfo.RefreshCPUList();
+		} catch (Exception e) {
+			Logger.Debug($"Exception was raised when detecting CPUs: {e.Message}");
+			return;
+		}
+
+		foreach (var cpu in hardwareInfo.CpuList) {
+			Logger.Debug($"CPU: {cpu.Name}");
+		}
 	}
 
 	public static void LogExecutableDirectory() {
@@ -52,6 +68,7 @@ public static class DebugInfo {
 
 	public static void LogEverything() {
 		LogSystemInfo();
+		LogCPUInfo();
 		LogExecutableDirectory();
 		LogAntivirusInfo();
 	}

--- a/commonItems/commonItems.csproj
+++ b/commonItems/commonItems.csproj
@@ -32,6 +32,7 @@
     <PackageReference Include="ColorHashSharp" Version="1.0.0" />
     <PackageReference Include="GameFinder.StoreHandlers.GOG" Version="4.3.3" />
     <PackageReference Include="GameFinder.StoreHandlers.Steam" Version="4.3.3" />
+    <PackageReference Include="Hardware.Info" Version="101.0.0" />
     <PackageReference Include="IcgSoftware.IntToOrdinalNumber" Version="1.0.0" />
     <PackageReference Include="log4net" Version="3.0.3" />
     <PackageReference Include="Microsoft.VisualBasic" Version="10.3.0" />

--- a/commonItems/commonItems.csproj
+++ b/commonItems/commonItems.csproj
@@ -6,7 +6,7 @@
 
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
     <PackageId>PGCG.$(AssemblyName)</PackageId>
-    <Version>15.0.2</Version>
+    <Version>15.1.0</Version>
     <Authors>PGCG</Authors>
     <PackageProjectUrl>https://github.com/ParadoxGameConverters/commonItems.NET</PackageProjectUrl>
     <RepositoryUrl>https://github.com/ParadoxGameConverters/commonItems.NET</RepositoryUrl>


### PR DESCRIPTION
Intel's 13th- and 14th-generation CPUs have instability problems which can potentially cause converter crashes. Logging the CPU name can be helpful when debugging issues reported to Sentry (allowing us to ignore problems from users that have these CPUs).